### PR TITLE
Case-insensitive category checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,14 @@ Then visit `http://localhost:8000` to browse the games.
 
 ## Adding Games
 
-Games are listed in `js/script.js` in the `games` array. Each entry defines the page id, title, description, thumbnail, source URL and genre. After adding to the array you should generate a game page in the `games/` directory. You can manually copy `games/template.html` or use the admin generator located at `admin/generator.html`.
+Games are listed in `js/games_data.js` in the `games` array. Each entry defines the page id, title, description, thumbnail, source URL and genre. After adding to the array you should generate a game page in the `games/` directory. You can manually copy `games/template.html` or use the admin generator located at `admin/generator.html`.
 
 Thumbnails for games live in `images/games/`. Make sure to add a suitable image for each game.
+
+## Game Categories
+
+The homepage allows visitors to filter games by genre. Available categories are **Action**, **Adventure**, **Puzzle**, **Strategy**, and **Sports**. Category names are matched case-insensitively.
+
 
 ## Logo Generator
 

--- a/index.html
+++ b/index.html
@@ -659,16 +659,20 @@
         function filterGamesByCategory(category) {
             // Clear all games container
             allGamesContainer.innerHTML = '';
-            
+
+            const selected = category.toLowerCase();
+
             // Filter and load games
-            if (category === 'all') {
+            if (selected === 'all') {
                 games.forEach(game => {
                     allGamesContainer.appendChild(createGameCard(game));
                 });
             } else {
-                games.filter(game => game.category === category).forEach(game => {
-                    allGamesContainer.appendChild(createGameCard(game));
-                });
+                games
+                    .filter(game => game.category.toLowerCase() === selected)
+                    .forEach(game => {
+                        allGamesContainer.appendChild(createGameCard(game));
+                    });
             }
         }
 
@@ -687,7 +691,12 @@
             
             // Load similar games (games in the same category)
             similarGamesContainer.innerHTML = '';
-            games.filter(g => g.category === game.category && g.id !== game.id)
+            games
+                .filter(
+                    g =>
+                        g.category.toLowerCase() === game.category.toLowerCase() &&
+                        g.id !== game.id
+                )
                 .slice(0, 4)
                 .forEach(similarGame => {
                     similarGamesContainer.appendChild(createGameCard(similarGame));


### PR DESCRIPTION
## Summary
- make `filterGamesByCategory` case-insensitive
- ensure similar games comparison ignores case
- clarify available categories in README

## Testing
- `node test_filters.js` *(counts categories)*
- `python3 -m http.server` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_68474eb4932c832fa752270f20bda55f